### PR TITLE
Disable AEM usage tracking by default for admins

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,6 +25,9 @@
 
     <release version="3.5.4" date="not released">
       <action type="update" dev="sseifert">
+        Disable AEM usage tracking by default for admins (esp. for local usage).
+      </action>
+      <action type="update" dev="sseifert">
         Update dependencies.
       </action>
     </release>

--- a/src/main/resources/archetype-resources/config-definition/src/main/templates/__projectName__-aem-cms/__projectName__-aem-cms-config.provisioning.hbs
+++ b/src/main/resources/archetype-resources/config-definition/src/main/templates/__projectName__-aem-cms/__projectName__-aem-cms-config.provisioning.hbs
@@ -62,6 +62,10 @@
   com.day.cq.commons.servlets.RootMappingServlet
     rootmapping.target="/sites.html"
 
+  # Disable usage tracking by default for admins (esp. for local usage)
+  com.adobe.cq.experiencelog.impl.ExperienceLogConfigServlet
+    disabledForGroups=["administrators"]
+
 #if ( $optionWcmioHandler == "y" )
   # Instance type
   io.wcm.wcm.commons.instancetype.impl.InstanceTypeServiceImpl


### PR DESCRIPTION
(esp. for local usage)