### PR TITLE
Eliminate "complete" package for AEMaaCS projects

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -23,7 +23,10 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 https://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
-    <release version="3.5.4" date="not released">
+    <release version="3.6.0" date="not released">
+      <action type="update" dev="sseifert">
+        Eliminate "complete" package for AEMaaCS projects and include application bundles directly in "all" content package. Use "all" content package also for local deployment to AEMaaCS SDK.
+      </action>
       <action type="update" dev="sseifert">
         Use "environments" as CONGA directory name instead of the customized "dev-environments".
       </action>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm.maven.archetypes</groupId>
   <artifactId>io.wcm.maven.archetypes.aem</artifactId>
-  <version>3.5.3-SNAPSHOT</version>
+  <version>3.6.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>wcm.io Maven Archetype for AEM</name>

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -17,6 +17,7 @@ def optionIntegrationTests = request.getProperties().get("optionIntegrationTests
 
 def coreBundle = new File(rootDir, "bundles/core")
 def clientlibsBundle = new File(rootDir, "bundles/clientlibs")
+def completeContentPackage = new File(rootDir, "content-packages/complete")
 def confContentPackage = new File(rootDir, "content-packages/conf-content")
 def sampleContentPackage = new File(rootDir, "content-packages/sample-content")
 def uiAppsPackage = new File(rootDir, "content-packages/ui.apps")
@@ -211,6 +212,10 @@ if (optionAemVersion == "cloud") {
   parentPom.newWriter("UTF-8").withWriter { w ->
     w << pomContent
   }
+
+  // delete complete package - deployment is done via "all" package which includes the application bundles
+  assert completeContentPackage.deleteDir()
+  removeModule(rootPom, "content-packages/complete")
 }
 else {
   // remove environments only relevant for AEMaaCS

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -373,7 +373,7 @@
 
     <module id="${rootArtifactId}.config-definition" dir="config-definition" name="${rootArtifactId}.config-definition">
       <fileSets>
-        <fileSet encoding="UTF-8">
+        <fileSet filtered="true" encoding="UTF-8">
           <directory></directory>
           <includes>
             <include>packages-upload.sh</include>

--- a/src/main/resources/archetype-resources/build-deploy.sh
+++ b/src/main/resources/archetype-resources/build-deploy.sh
@@ -199,7 +199,11 @@ execute_deploy() {
     MAVEN_ARGS+="--activate-profiles=${MAVEN_PROFILES} "
   fi
   if [ -n "${CONGA_ENVIRONMENT}" ] && [ -n "${CONGA_NODE}" ]; then
+#if ( $optionAemVersion == "cloud" )
+    MAVEN_ARGS+="-Dvault.file=target/${CONGA_ENVIRONMENT}.${CONGA_NODE}.all.zip -Dvault.force=true"
+#else
     MAVEN_ARGS+="-Dconga.environments=${CONGA_ENVIRONMENT} -Dconga.nodeDirectory=target/configuration/${CONGA_ENVIRONMENT}/${CONGA_NODE} "
+#end
   fi
   if [ -n "${SLING_URL}" ]; then
     MAVEN_ARGS+="-Dsling.url=${SLING_URL} "
@@ -211,7 +215,11 @@ execute_deploy() {
     MAVEN_ARGS+="-Dsling.password=${SLING_PASSWORD} "
   fi
 
+#if ( $optionAemVersion == "cloud" )
+  mvn $MAVEN_ARGS -f config-definition wcmio-content-package:install
+#else
   mvn $MAVEN_ARGS -f config-definition conga-aem:package-install
+#end
 
   if [ "$?" -ne "0" ]; then
     exit_with_error "*** DEPLOY FAILED ***"

--- a/src/main/resources/archetype-resources/config-definition/packages-upload.sh
+++ b/src/main/resources/archetype-resources/config-definition/packages-upload.sh
@@ -2,7 +2,7 @@
 # #%L
 #  wcm.io
 #  %%
-#  Copyright (C) 2017 wcm.io
+#  Copyright (C) 2017 - 2022 wcm.io
 #  %%
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -25,7 +25,11 @@ if [[ $0 == *":\\"* ]]; then
   DISPLAY_PAUSE_MESSAGE=true
 fi
 
+#if ( $optionAemVersion == "cloud" )
+mvn -Pfast -Dvault.file=target/${CONGA_ENVIRONMENT}.${CONGA_NODE}.all.zip -Dvault.force=true clean install wcmio-content-package:install
+#else
 mvn -Pfast -Dconga.environments=${CONGA_ENVIRONMENT} -Dconga.nodeDirectory=target/configuration/${CONGA_ENVIRONMENT}/${CONGA_NODE} clean install conga-aem:package-install
+#end
 
 if [ "$DISPLAY_PAUSE_MESSAGE" = true ]; then
   echo ""

--- a/src/main/resources/archetype-resources/config-definition/pom.xml
+++ b/src/main/resources/archetype-resources/config-definition/pom.xml
@@ -26,7 +26,23 @@
       <scope>compile</scope>
     </dependency>
 
-    <!-- Application packages -->
+    <!-- Application #if($optionAemVersion=='cloud')bundles and#{end}packages -->
+#if ( $optionAemVersion == "cloud" )
+    <dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>${rootArtifactId}.core</artifactId>
+      <version>${version}</version>
+      <scope>provided</scope>
+    </dependency>
+#if ( $optionMultiBundleLayout == "y" )
+    <dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>${rootArtifactId}.clientlibs</artifactId>
+      <version>${version}</version>
+      <scope>provided</scope>
+    </dependency>
+#end
+#else
     <dependency>
       <groupId>${groupId}</groupId>
       <artifactId>${rootArtifactId}.complete</artifactId>
@@ -34,6 +50,7 @@
       <type>zip</type>
       <scope>compile</scope>
     </dependency>
+#end
 #if ( $optionSlingInitialContentBundle == "y" && $optionSlingInitialContentBundleContentPackage == "y" && $optionAemVersion == "cloud" )
     <dependency>
       <groupId>${groupId}</groupId>
@@ -109,8 +126,18 @@
 
 #end
 #if ( $optionAemVersion == "cloud" && ($optionContextAwareConfig == "y" || $optionWcmioHandler == "y") )
-    <!-- wcm.io - Content packages with Sling-Initial-Content, see https://wcm-io.atlassian.net/l/c/d2FuEgf8 for details -->
+    <!-- wcm.io -->
 #if ( $optionContextAwareConfig == "y" )
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.caconfig.extensions</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.caconfig.editor</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.caconfig.editor</artifactId>
@@ -122,30 +149,17 @@
 #if ( $optionWcmioHandler == "y" )
     <dependency>
       <groupId>io.wcm</groupId>
-      <artifactId>io.wcm.handler.url</artifactId>
-      <classifier>content</classifier>
-      <type>zip</type>
+      <artifactId>io.wcm.sling.commons</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.wcm</groupId>
-      <artifactId>io.wcm.handler.link</artifactId>
-      <classifier>content</classifier>
-      <type>zip</type>
+      <artifactId>io.wcm.sling.models</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.wcm</groupId>
-      <artifactId>io.wcm.handler.media</artifactId>
-      <classifier>content</classifier>
-      <type>zip</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.wcm</groupId>
-      <artifactId>io.wcm.handler.richtext</artifactId>
-      <classifier>content</classifier>
-      <type>zip</type>
+      <artifactId>io.wcm.wcm.commons</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -157,9 +171,7 @@
     </dependency>
     <dependency>
       <groupId>io.wcm</groupId>
-      <artifactId>io.wcm.wcm.core.components</artifactId>
-      <classifier>content</classifier>
-      <type>zip</type>
+      <artifactId>io.wcm.wcm.parsys</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -172,6 +184,11 @@
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.wcm.ui.granite</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.wcm.ui.granite</artifactId>
       <classifier>content</classifier>
       <type>zip</type>
       <scope>compile</scope>
@@ -179,6 +196,76 @@
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.wcm.ui.clientlibs</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.wcm.ui.clientlibs</artifactId>
+      <classifier>content</classifier>
+      <type>zip</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.commons</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.url</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.url</artifactId>
+      <classifier>content</classifier>
+      <type>zip</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.media</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.media</artifactId>
+      <classifier>content</classifier>
+      <type>zip</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.link</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.link</artifactId>
+      <classifier>content</classifier>
+      <type>zip</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.richtext</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.handler.richtext</artifactId>
+      <classifier>content</classifier>
+      <type>zip</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.wcm.core.components</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.wcm</groupId>
+      <artifactId>io.wcm.wcm.core.components</artifactId>
       <classifier>content</classifier>
       <type>zip</type>
       <scope>compile</scope>
@@ -286,7 +373,6 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
-        <conga.cloudManager.allPackage.skip>true</conga.cloudManager.allPackage.skip>
         <conga.cloudManager.dispatcherConfig.skip>true</conga.cloudManager.dispatcherConfig.skip>
         <aem.analyser.skip>true</aem.analyser.skip>
       </properties>

--- a/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
@@ -78,34 +78,71 @@ files:
 #if ( $optionAemVersion == "cloud" && ($optionContextAwareConfig == "y" || $optionWcmioHandler == "y") )
 # wcm.io
 #if ( $optionContextAwareConfig == "y" )
+- url: mvn:io.wcm/io.wcm.caconfig.extensions
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.caconfig.editor
+  dir: bundles
 - url: mvn:io.wcm/io.wcm.caconfig.editor//zip/content
   dir: packages
 #end
 #if ( $optionWcmioHandler == "y" )
-- url: mvn:io.wcm/io.wcm.handler.url//zip/content
-  dir: packages
-- url: mvn:io.wcm/io.wcm.handler.link//zip/content
-  dir: packages
-- url: mvn:io.wcm/io.wcm.handler.media//zip/content
-  dir: packages
-- url: mvn:io.wcm/io.wcm.handler.richtext//zip/content
-  dir: packages
+- url: mvn:io.wcm/io.wcm.sling.commons
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.sling.models
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.wcm.commons
+  dir: bundles
 - url: mvn:io.wcm/io.wcm.wcm.commons//zip/content
   dir: packages
-- url: mvn:io.wcm/io.wcm.wcm.core.components//zip/content
-  dir: packages
+- url: mvn:io.wcm/io.wcm.wcm.parsys
+  dir: bundles
 - url: mvn:io.wcm/io.wcm.wcm.parsys//zip/content
   dir: packages
+- url: mvn:io.wcm/io.wcm.wcm.ui.granite
+  dir: bundles
 - url: mvn:io.wcm/io.wcm.wcm.ui.granite//zip/content
   dir: packages
+- url: mvn:io.wcm/io.wcm.wcm.ui.clientlibs
+  dir: bundles
 - url: mvn:io.wcm/io.wcm.wcm.ui.clientlibs//zip/content
+  dir: packages
+- url: mvn:io.wcm/io.wcm.handler.commons
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.handler.url
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.handler.url//zip/content
+  dir: packages
+- url: mvn:io.wcm/io.wcm.handler.media
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.handler.media//zip/content
+  dir: packages
+- url: mvn:io.wcm/io.wcm.handler.link
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.handler.link//zip/content
+  dir: packages
+- url: mvn:io.wcm/io.wcm.handler.richtext
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.handler.richtext//zip/content
+  dir: packages
+- url: mvn:io.wcm/io.wcm.wcm.core.components
+  dir: bundles
+- url: mvn:io.wcm/io.wcm.wcm.core.components//zip/content
   dir: packages
 #end
 
 #end
-# Application package
+# Application #if($optionAemVersion=='cloud')bundles and#{end}packages
+#if ( $optionAemVersion == "cloud" )
+- url: mvn:${groupId}/${rootArtifactId}.core
+  dir: bundles
+#if ( $optionMultiBundleLayout == "y" )
+- url: mvn:${groupId}/${rootArtifactId}.clientlibs
+  dir: bundles
+#end
+#else
 - url: mvn:${groupId}/${rootArtifactId}.complete//zip
   dir: packages
+#end
 #if ( $optionSlingInitialContentBundle == "y" && $optionSlingInitialContentBundleContentPackage == "y" && $optionAemVersion == "cloud" )
 - url: mvn:${groupId}/${rootArtifactId}.core//zip/content
   dir: packages

--- a/src/main/resources/archetype-resources/content-packages/complete/pom.xml
+++ b/src/main/resources/archetype-resources/content-packages/complete/pom.xml
@@ -38,15 +38,6 @@
       <scope>provided</scope>
     </dependency>
 #end
-#if ( $optionSlingInitialContentBundle == "n" )
-    <dependency>
-      <groupId>${groupId}</groupId>
-      <artifactId>${rootArtifactId}.ui.apps</artifactId>
-      <version>${version}</version>
-      <type>zip</type>
-      <scope>provided</scope>
-    </dependency>
-#end
 
 #if ( $optionAemVersion != "cloud" )
 #if ( $optionSlingModelsLatest == "y" )

--- a/src/main/resources/archetype-resources/parent/pom.xml
+++ b/src/main/resources/archetype-resources/parent/pom.xml
@@ -161,14 +161,70 @@
 #if ( $optionWcmioHandler == "y" )
       <dependency>
         <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.sling.commons</artifactId>
+        <version>1.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.wcm</groupId>
         <artifactId>io.wcm.sling.models</artifactId>
         <version>1.6.0</version>
       </dependency>
       <dependency>
         <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.sling.commons</artifactId>
-        <version>1.4.0</version>
+        <artifactId>io.wcm.wcm.commons</artifactId>
+        <version>1.9.0</version>
       </dependency>
+#if ( $optionAemVersion == "cloud" )
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.commons</artifactId>
+        <version>1.9.0</version>
+        <classifier>content</classifier>
+        <type>zip</type>
+      </dependency>
+#end
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.parsys</artifactId>
+        <version>1.6.8</version>
+      </dependency>
+#if ( $optionAemVersion == "cloud" )
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.parsys</artifactId>
+        <version>1.6.8</version>
+        <classifier>content</classifier>
+        <type>zip</type>
+      </dependency>
+#end
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.ui.granite</artifactId>
+        <version>1.9.2</version>
+      </dependency>
+#if ( $optionAemVersion == "cloud" )
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.ui.granite</artifactId>
+        <version>1.9.2</version>
+        <classifier>content</classifier>
+        <type>zip</type>
+      </dependency>
+#end
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.ui.clientlibs</artifactId>
+        <version>1.2.2</version>
+      </dependency>
+#if ( $optionAemVersion == "cloud" )
+      <dependency>
+        <groupId>io.wcm</groupId>
+        <artifactId>io.wcm.wcm.ui.clientlibs</artifactId>
+        <version>1.2.2</version>
+        <classifier>content</classifier>
+        <type>zip</type>
+      </dependency>
+#end
       <dependency>
         <groupId>io.wcm</groupId>
         <artifactId>io.wcm.handler.commons</artifactId>
@@ -190,28 +246,28 @@
 #end
       <dependency>
         <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.handler.link</artifactId>
-        <version>1.9.2</version>
+        <artifactId>io.wcm.handler.media</artifactId>
+        <version>1.14.2</version>
       </dependency>
 #if ( $optionAemVersion == "cloud" )
       <dependency>
         <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.handler.link</artifactId>
-        <version>1.9.2</version>
+        <artifactId>io.wcm.handler.media</artifactId>
+        <version>1.14.2</version>
         <classifier>content</classifier>
         <type>zip</type>
       </dependency>
 #end
       <dependency>
         <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.handler.media</artifactId>
-        <version>1.14.2</version>
+        <artifactId>io.wcm.handler.link</artifactId>
+        <version>1.9.2</version>
       </dependency>
 #if ( $optionAemVersion == "cloud" )
       <dependency>
         <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.handler.media</artifactId>
-        <version>1.14.2</version>
+        <artifactId>io.wcm.handler.link</artifactId>
+        <version>1.9.2</version>
         <classifier>content</classifier>
         <type>zip</type>
       </dependency>
@@ -232,20 +288,6 @@
 #end
       <dependency>
         <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.commons</artifactId>
-        <version>1.9.0</version>
-      </dependency>
-#if ( $optionAemVersion == "cloud" )
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.commons</artifactId>
-        <version>1.9.0</version>
-        <classifier>content</classifier>
-        <type>zip</type>
-      </dependency>
-#end
-      <dependency>
-        <groupId>io.wcm</groupId>
         <artifactId>io.wcm.wcm.core.components</artifactId>
         <version>1.10.0-2.18.6</version>
       </dependency>
@@ -254,48 +296,6 @@
         <groupId>io.wcm</groupId>
         <artifactId>io.wcm.wcm.core.components</artifactId>
         <version>1.10.0-2.18.6</version>
-        <classifier>content</classifier>
-        <type>zip</type>
-      </dependency>
-#end
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.parsys</artifactId>
-        <version>1.6.8</version>
-      </dependency>
-#if ( $optionAemVersion == "cloud" )
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.parsys</artifactId>
-        <version>1.6.8</version>
-        <classifier>content</classifier>
-        <type>zip</type>
-      </dependency>
-#end
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.ui.granite</artifactId>
-        <version>1.9.2</version>
-      </dependency>
-#if ( $optionAemVersion == "cloud" )
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.ui.granite</artifactId>
-        <version>1.9.2</version>
-        <classifier>content</classifier>
-        <type>zip</type>
-      </dependency>
-#end
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.ui.clientlibs</artifactId>
-        <version>1.2.2</version>
-      </dependency>
-#if ( $optionAemVersion == "cloud" )
-      <dependency>
-        <groupId>io.wcm</groupId>
-        <artifactId>io.wcm.wcm.ui.clientlibs</artifactId>
-        <version>1.2.2</version>
         <classifier>content</classifier>
         <type>zip</type>
       </dependency>


### PR DESCRIPTION
Eliminate "complete" package for AEMaaCS projects and include application bundles directly in "all" content package.
Use "all" content package also for local deployment to AEMaaCS SDK.