### PR TITLE
AEMaaCS projects: Introduce CONGA parameter aem.disableAuthorUsageStatisticsCollection to disable usage tracking on AEM author instance

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -28,6 +28,9 @@
         CONGA "all" package generation: Set runModeOptimization=ELIMINATE_DUPLICATES which produces only a single "all" package.
       </action>
       <action type="update" dev="sseifert">
+        AEMaaCS projects: Introduce CONGA parameter aem.disableAuthorUsageStatisticsCollection to disable usage tracking on AEM author instances (activated by default for local environment).
+      </action>
+      <action type="update" dev="sseifert">
         Update dependencies.
       </action>
       <action type="update" dev="sseifert">

--- a/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
@@ -32,6 +32,13 @@ nodes:
 
 config:
   contentPackage.group: ${packageGroupName}
+
+#if ( $optionAemVersion == "cloud" )
+  aem:
+    # Disable user tracking in author environment
+    disableAuthorUsageStatisticsCollection: false
+
+#end
   app:
     # Default log level for application code
     logLevel: warn

--- a/src/main/resources/archetype-resources/config-definition/src/main/environments/local.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/environments/local.yaml
@@ -24,6 +24,13 @@ nodes:
 
 config:
   contentPackage.group: ${packageGroupName}
+
+#if ( $optionAemVersion == "cloud" )
+  aem:
+    # Disable user tracking in author environment
+    disableAuthorUsageStatisticsCollection: true
+
+#end
   app:
     # Default log level for application code
     logLevel: info

--- a/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
@@ -175,6 +175,12 @@ config:
     group: ${packageGroupName}
     #[[version: ${version}]]#
 
+#if ( $optionAemVersion == "cloud" )
+  aem:
+    # Disable user tracking in author environment
+    disableAuthorUsageStatisticsCollection: false
+
+#end
   app:
 #if ( $optionContextAwareConfig == "y" || $optionEditableTemplates == "y" )
     confContent: true

--- a/src/main/resources/archetype-resources/config-definition/src/main/templates/__projectName__-aem-cms/__projectName__-aem-cms-config.provisioning.hbs
+++ b/src/main/resources/archetype-resources/config-definition/src/main/templates/__projectName__-aem-cms/__projectName__-aem-cms-config.provisioning.hbs
@@ -62,6 +62,14 @@
   com.day.cq.commons.servlets.RootMappingServlet
     rootmapping.target="/sites.html"
 
+#if ( $optionAemVersion == "cloud" )
+#[[{{#if aem.disableAuthorUsageStatisticsCollection ~}}]]#
+  # Disable usage tracking by default for admins (esp. for local usage)
+  com.adobe.cq.experiencelog.impl.ExperienceLogConfigServlet
+    enabled=B"false"
+
+{{/if ~}}
+#end
 #if ( $optionWcmioHandler == "y" )
   # Instance type
   io.wcm.wcm.commons.instancetype.impl.InstanceTypeServiceImpl


### PR DESCRIPTION
(activated by default for local environment)