### PR TITLE
Switch to acs-aem-commons-all artifact for ACS AEM Commons deployment

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -31,6 +31,9 @@
         Add Sling Model Exporter definition for CustomCarousel sample component.
       </action>
       <action type="update" dev="sseifert">
+        Switch to acs-aem-commons-all artifact for ACS AEM Commons deployment.
+      </action>
+      <action type="update" dev="sseifert">
         Update dependencies.
       </action>
     </release>

--- a/src/main/resources/archetype-resources/config-definition/pom.xml
+++ b/src/main/resources/archetype-resources/config-definition/pom.xml
@@ -89,22 +89,9 @@
 #end
 #if( $optionAcsCommons == "y" )
     <!-- ACS AEM Commons -->
-#if ( $optionAemVersion == "cloud" )
     <dependency>
       <groupId>com.adobe.acs</groupId>
-      <artifactId>acs-aem-commons-bundle</artifactId>
-      <scope>compile</scope>
-    </dependency>
-#end
-    <dependency>
-      <groupId>com.adobe.acs</groupId>
-      <artifactId>acs-aem-commons-ui.apps</artifactId>
-      <type>zip</type>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.adobe.acs</groupId>
-      <artifactId>acs-aem-commons-ui.content</artifactId>
+      <artifactId>acs-aem-commons-all</artifactId>
       <type>zip</type>
       <scope>compile</scope>
     </dependency>

--- a/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
@@ -28,18 +28,8 @@ files:
 #end
 #if( $optionAcsCommons == "y" )
 # ACS AEM Commons
-#if ( $optionAemVersion == "cloud" )
-- url: mvn:com.adobe.acs/acs-aem-commons-bundle
-  dir: bundles
-#end
-- url: mvn:com.adobe.acs/acs-aem-commons-ui.apps//zip
+- url: mvn:com.adobe.acs/acs-aem-commons-all//zip
   dir: packages
-  postProcessorOptions:
-    contentPackage.packageType: application
-- url: mvn:com.adobe.acs/acs-aem-commons-ui.content//zip
-  dir: packages
-  postProcessorOptions:
-    contentPackage.packageType: content
 
 #end
 # AEM OSGi System Configuration

--- a/src/main/resources/archetype-resources/content-packages/complete/pom.xml
+++ b/src/main/resources/archetype-resources/content-packages/complete/pom.xml
@@ -88,15 +88,6 @@
     </dependency>
 #end
 
-#if ( $optionAcsCommons == "y" && $optionAemVersion != "cloud" )
-    <!-- ACS AEM Commons -->
-    <dependency>
-      <groupId>com.adobe.acs</groupId>
-      <artifactId>acs-aem-commons-bundle</artifactId>
-      <scope>compile</scope>
-    </dependency>
-
-#end
   </dependencies>
 
   <build>
@@ -170,18 +161,6 @@
               <type>jar</type>
             </embedded>
 #end
-#end
-#if( $optionAcsCommons == "y" && $optionAemVersion != "cloud" )
-            <!-- ACS AEM Commons -->
-            <embedded>
-              <groupId>
-                com.adobe.acs
-              </groupId>
-              <artifactId>
-                acs-aem-commons-bundle
-              </artifactId>
-              <type>jar</type>
-            </embedded>
 #end
           </embeddeds>
 

--- a/src/main/resources/archetype-resources/parent/pom.xml
+++ b/src/main/resources/archetype-resources/parent/pom.xml
@@ -342,13 +342,7 @@
       </dependency>
       <dependency>
         <groupId>com.adobe.acs</groupId>
-        <artifactId>acs-aem-commons-ui.apps</artifactId>
-        <version>${acs.aem.commons.version}</version>
-        <type>zip</type>
-      </dependency>
-      <dependency>
-        <groupId>com.adobe.acs</groupId>
-        <artifactId>acs-aem-commons-ui.content</artifactId>
+        <artifactId>acs-aem-commons-all</artifactId>
         <version>${acs.aem.commons.version}</version>
         <type>zip</type>
       </dependency>


### PR DESCRIPTION
following instructions for v6.0.x in https://adobe-consulting-services.github.io/acs-aem-commons/pages/maven.html