### PR TITLE
Configure httpd.headers.htmlExpirationTimeSec conditionally

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
 
     <release version="3.8.2" date="not released">
       <action type="update" dev="sseifert"><![CDATA[
-        Dispatcher Configuration for AEMaaCS: Configure <code>httpd.headers.htmlExpirationTimeSec</code> conditionally per environment (DEV: 0 sec, STAGE/PROD: 300 sec by default).
+        Dispatcher Configuration for AEMaaCS: Configure <code>httpd.headers.htmlExpirationTimeSec</code> conditionally per environment (DEV: 5 sec, STAGE/PROD: 300 sec by default).
       ]]></action>
       <action type="update" dev="sseifert">
         Update to AEM 6.5 SP17.

--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="3.8.2" date="not released">
+      <action type="update" dev="sseifert"><![CDATA[
+        Dispatcher Configuration for AEMaaCS: Configure <code>httpd.headers.htmlExpirationTimeSec</code> conditionally per environment (DEV: 0 sec, STAGE/PROD: 300 sec by default).
+      ]]></action>
       <action type="update" dev="sseifert">
         Update to AEM 6.5 SP17.
       </action>

--- a/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
@@ -66,9 +66,12 @@ config:
     sampleContent: true
 
   httpd:
-    headers:
-      # Set default expiration time for text/html responses (also affects dispatcher caching/invalidation)
-      htmlExpirationTimeSec: 0
+    # Set default expiration time for text/html responses (also affects dispatcher caching/invalidation)
+    # Configuration is different per dev/stage/prod environment
+    cloudManagerConditional:
+      dev.headers.htmlExpirationTimeSec: 0
+      stage.headers.htmlExpirationTimeSec: 300
+      prod.headers.htmlExpirationTimeSec: 300
 
   # Replication configuration not required for AEM cloud service
   replication:

--- a/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
@@ -69,7 +69,7 @@ config:
     # Set default expiration time for text/html responses (also affects dispatcher caching/invalidation)
     # Configuration is different per dev/stage/prod environment
     cloudManagerConditional:
-      dev.headers.htmlExpirationTimeSec: 0
+      dev.headers.htmlExpirationTimeSec: 5
       stage.headers.htmlExpirationTimeSec: 300
       prod.headers.htmlExpirationTimeSec: 300
 


### PR DESCRIPTION
Configure `httpd.headers.htmlExpirationTimeSec` conditionally per environment (DEV: 5 sec, STAGE/PROD: 300 sec by default)