### PR TITLE
Apply Mixin for JSONP 1.1 when wcm.io Handler is not activated for compatibility with Adobe AEM WCM Core Components implementation

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -24,6 +24,9 @@
   <body>
 
     <release version="3.8.14" date="not released">
+      <action type="update" dev="sseifert"><![CDATA[
+        Apply <a href="https://github.com/wcm-io/io.wcm.maven.aem-cloud-dependencies-mixin-jsonp11">AEM Cloud Service Dependencies - Mixin for JSONP 1.1</a> when wcm.io Handler is not activated for compatibility with Adobe AEM WCM Core Components implementation.
+      ]]></action>
       <action type="update" dev="sseifert">
         Update dependencies.
       </action>

--- a/changes.xml
+++ b/changes.xml
@@ -24,7 +24,7 @@
   <body>
 
     <release version="3.8.14" date="not released">
-      <action type="update" dev="sseifert"><![CDATA[
+      <action type="update" dev="sseifert" issue="66"><![CDATA[
         Apply <a href="https://github.com/wcm-io/io.wcm.maven.aem-cloud-dependencies-mixin-jsonp11">AEM Cloud Service Dependencies - Mixin for JSONP 1.1</a> when wcm.io Handler is not activated for compatibility with Adobe AEM WCM Core Components implementation.
       ]]></action>
       <action type="update" dev="sseifert">

--- a/src/main/resources/archetype-resources/parent/pom.xml
+++ b/src/main/resources/archetype-resources/parent/pom.xml
@@ -310,6 +310,17 @@
         <scope>import</scope>
       </dependency>
 #else
+#if ( $optionWcmioHandler != "y" )
+      <!-- Adobe AEM WCM Core Components implementation relies on JSONP1.1 -->
+      <dependency>
+        <groupId>io.wcm.maven</groupId>
+        <artifactId>io.wcm.maven.aem-cloud-dependencies-mixin-jsonp11</artifactId>
+## renovate: depName=io.wcm.maven:io.wcm.maven.aem-cloud-dependencies-mixin-jsonp11
+        <version>1.0.0-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+#end
       <dependency>
         <groupId>io.wcm.maven</groupId>
         <artifactId>io.wcm.maven.aem-cloud-dependencies</artifactId>


### PR DESCRIPTION
related to https://github.com/wcm-io/io.wcm.maven.aem-cloud-dependencies/pull/66