### PR TITLE
Include wcm.io Parsys module only for projects without AEM editable templates

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="update" dev="sseifert">
         Update dependencies.
       </action>
+      <action type="update" dev="sseifert">
+        Include wcm.io Parsys module only for projects without AEM editable templates.
+      </action>
     </release>
 
     <release version="3.8.14" date="2024-07-18">

--- a/changes.xml
+++ b/changes.xml
@@ -27,7 +27,7 @@
       <action type="update" dev="sseifert">
         Update dependencies.
       </action>
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="83">
         Include wcm.io Parsys module only for projects without AEM editable templates.
       </action>
     </release>

--- a/src/main/resources/archetype-resources/bundles/core/pom.xml
+++ b/src/main/resources/archetype-resources/bundles/core/pom.xml
@@ -102,11 +102,13 @@
       <artifactId>io.wcm.wcm.core.components</artifactId>
       <scope>compile</scope>
     </dependency>
+#if ( $optionEditableTemplates != "y" )
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.wcm.parsys</artifactId>
       <scope>compile</scope>
     </dependency>
+#end
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.wcm.ui.granite</artifactId>

--- a/src/main/resources/archetype-resources/config-definition/pom.xml
+++ b/src/main/resources/archetype-resources/config-definition/pom.xml
@@ -127,11 +127,13 @@
       <artifactId>io.wcm.wcm.commons</artifactId>
       <scope>compile</scope>
     </dependency>
+#if ( $optionEditableTemplates != "y" )
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.wcm.parsys</artifactId>
       <scope>compile</scope>
     </dependency>
+#end
     <dependency>
       <groupId>io.wcm</groupId>
       <artifactId>io.wcm.wcm.ui.granite</artifactId>

--- a/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/roles/__projectName__-aem-cms.yaml
@@ -86,8 +86,10 @@ files:
   dir: bundles
 - url: mvn:io.wcm/io.wcm.wcm.commons
   dir: bundles
+#if ( $optionEditableTemplates != "y" )
 - url: mvn:io.wcm/io.wcm.wcm.parsys
   dir: bundles
+#end
 - url: mvn:io.wcm/io.wcm.wcm.ui.granite
   dir: bundles
 - url: mvn:io.wcm/io.wcm.wcm.ui.clientlibs

--- a/src/main/resources/archetype-resources/parent/pom.xml
+++ b/src/main/resources/archetype-resources/parent/pom.xml
@@ -174,12 +174,14 @@
 ## renovate: depName=io.wcm:io.wcm.wcm.commons
         <version>1.11.0</version>
       </dependency>
+#if ( $optionEditableTemplates != "y" )
       <dependency>
         <groupId>io.wcm</groupId>
         <artifactId>io.wcm.wcm.parsys</artifactId>
 ## renovate: depName=io.wcm:io.wcm.wcm.parsys
         <version>1.7.4</version>
       </dependency>
+#end
       <dependency>
         <groupId>io.wcm</groupId>
         <artifactId>io.wcm.wcm.ui.granite</artifactId>


### PR DESCRIPTION
When using editable templates, features of the template editor should be used to control which components are allowed at which position (although this is less flexible and more cumbersome to maintain).