### PR TITLE
Remove obsolete workaround for JCRVLT-699

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -30,7 +30,7 @@
       <action type="update" dev="sseifert" issue="83">
         Include wcm.io Parsys module only for projects without AEM editable templates.
       </action>
-      <action type="update" dev="sseifert"><![CDATA[
+      <action type="update" dev="sseifert" issue="89"><![CDATA[
         Remove obsolete workaround for <a href="https://issues.apache.org/jira/browse/JCRVLT-699">JCRVLT-699</a>.
       ]]></action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -30,6 +30,9 @@
       <action type="update" dev="sseifert" issue="83">
         Include wcm.io Parsys module only for projects without AEM editable templates.
       </action>
+      <action type="update" dev="sseifert"><![CDATA[
+        Remove obsolete workaround for <a href="https://issues.apache.org/jira/browse/JCRVLT-699">JCRVLT-699</a>.
+      ]]></action>
     </release>
 
     <release version="3.8.14" date="2024-07-18">

--- a/src/main/resources/archetype-resources/content-packages/conf-content/pom.xml
+++ b/src/main/resources/archetype-resources/content-packages/conf-content/pom.xml
@@ -20,9 +20,6 @@
   <properties>
     <contentPackage.name>${projectName}-conf-content</contentPackage.name>
     <contentPackage.group>${packageGroupName}</contentPackage.group>
-
-    <!-- Disable reproducible builds for this package as workaround for https://issues.apache.org/jira/browse/JCRVLT-699 -->
-    <project.build.outputTimestamp></project.build.outputTimestamp>
   </properties>
 
   <build>

--- a/src/main/resources/archetype-resources/content-packages/sample-content/pom.xml
+++ b/src/main/resources/archetype-resources/content-packages/sample-content/pom.xml
@@ -20,9 +20,6 @@
   <properties>
     <contentPackage.name>${projectName}-sample-content</contentPackage.name>
     <contentPackage.group>${packageGroupName}</contentPackage.group>
-
-    <!-- Disable reproducible builds for this package as workaround for https://issues.apache.org/jira/browse/JCRVLT-699 -->
-    <project.build.outputTimestamp></project.build.outputTimestamp>
   </properties>
 
   <build>

--- a/src/main/resources/archetype-resources/content-packages/ui.apps/pom.xml
+++ b/src/main/resources/archetype-resources/content-packages/ui.apps/pom.xml
@@ -20,9 +20,6 @@
   <properties>
     <contentPackage.name>${projectName}-ui.apps</contentPackage.name>
     <contentPackage.group>${packageGroupName}</contentPackage.group>
-
-    <!-- Disable reproducible builds for this package as workaround for https://issues.apache.org/jira/browse/JCRVLT-699 -->
-    <project.build.outputTimestamp></project.build.outputTimestamp>
   </properties>
 
   <build>


### PR DESCRIPTION
Woraround for https://issues.apache.org/jira/browse/JCRVLT-699 no longer required, we can enable reproducible builds again for all content packages.

It was only relevant for AEMaaCS, and that was updated to FileVault 3.7.0 quite a time ago in 2023.