### PR TITLE
Refactor integration tests successfully run them on AEMaaCS author and publish instances

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -31,6 +31,9 @@
       <action type="update" dev="sseifert">
         Update to AEM 6.5 SP22.
       </action>
+      <action type="update" dev="sseifert">
+        Refactor integration tests successfully run them on AEMaaCS author and publish instances. Allow accessing content with unshortened path if integration tests are enabled.
+      </action>
     </release>
 
     <release version="3.9.2" date="2024-11-18">

--- a/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
+++ b/src/main/resources/archetype-resources/config-definition/src/main/environments/cloud.yaml
@@ -80,4 +80,9 @@ tenants:
       #  stage.serverName: publish-XXX.adobeaemcloud.com
       #  prod.serverName: publish-XXX.adobeaemcloud.com
       rootRedirect.url: /en.html
-    sling.mapping.rootPath: /content/${projectName}
+    sling.mapping:
+      rootPath: /content/${projectName}
+#if ( $optionIntegrationTests == "y" )
+      # required for integration tests
+      allowUnshortenedPath: true
+#end


### PR DESCRIPTION
Allow accessing content with unshortened path if integration tests are enabled

Fixes #165